### PR TITLE
Don’t use short tags

### DIFF
--- a/map.php
+++ b/map.php
@@ -1,4 +1,4 @@
-<? # Kirby Map Plugin
+<?php # Kirby Map Plugin
 
 $kirby->set('field', 'map', __DIR__ . '/fields/map');
 


### PR DESCRIPTION
As I tried using the plugin the panel just displayed the contents of this file because `short_open_tag` was not enabled. Also see http://php.net/manual/en/language.basic-syntax.phptags.php
