### PR TITLE
Fix data loss

### DIFF
--- a/fields/map/map.php
+++ b/fields/map/map.php
@@ -179,10 +179,10 @@
 
   public function result() {
     # Get Incoming data, which should be a nested object containing `lat`, `lng`, `zoom`, and `address` properties
-    $input = parent::result();
-
-    # Store as Yaml.
-    return yaml::encode($input);
+    if ($input = parent::result()) {
+      # Store as Yaml.
+      return yaml::encode($input);
+    }
 
     # This ends up as a text block when stored inside a Structure field. Really, it's plain text anywhere it's stored— but the effect is only noticeable there. The truth is that Structure fields are stored as "plain text," as-is, which may be the only way to legitimately implement nested structures. For example, how do we "stop" YAML from being parsed at a certain hierarchical level?
   }

--- a/fields/map/map.php
+++ b/fields/map/map.php
@@ -98,6 +98,7 @@
     $lat_input = new Brick('input');
     $lat_input->attr('tabindex', '-1');
     $lat_input->attr('readonly', true);
+    $lat_input->attr('disabled', $this->disabled());
     $lat_input->attr('name', $this->name() . '[lat]');
     $lat_input->addClass('input input-split-left input-is-readonly map-lat');
     $lat_input->attr('placeholder', l::get('fields.map.latitude', 'Latitude'));
@@ -119,6 +120,7 @@
     $lng_input = new Brick('input');
     $lng_input->attr('tabindex', '-1');
     $lng_input->attr('readonly', true);
+    $lng_input->attr('disabled', $this->disabled());
     $lng_input->attr('name', $this->name() . '[lng]');
     $lng_input->addClass('input input-split-right input-is-readonly map-lng');
     $lng_input->attr('placeholder', l::get('fields.map.longitude', 'Longitude'));
@@ -140,6 +142,7 @@
     $zoom_input = new Brick('input');
     $zoom_input->attr('tabindex', '-1');
     $zoom_input->attr('readonly', true);
+    $zoom_input->attr('disabled', $this->disabled());
     $zoom_input->attr('type', 'hidden');
     $zoom_input->attr('name', $this->name() . '[zoom]');
     $zoom_input->addClass('input input-is-readonly map-zoom');


### PR DESCRIPTION
Hi @AugustMiller,

I have experienced an issue when I set the field as disabled for some roles (via a custom plugin) and the map plugin loses the address when the page is saved. The causes are:

1. Out of the 4 inputs used by map, only the address input respected the "disabled" option in the blueprint. When the page was saved, only `location[lat]`, `location[lng]`, and `location[zoom]` where being sent, encoded to yaml and saved.

1. After fixing the issue above, it was losing the value for all 4 inputs. That's because you were getting the value of the `location` array, which was null in that case, and encoding it to yaml which was then saved as an empty string. I added a check to only encode and save when the value isn't null.

Thank you for this great plugin!